### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/canstralian/parrot_mcp_server/security/code-scanning/1](https://github.com/canstralian/parrot_mcp_server/security/code-scanning/1)

To fix the issue, you should add a `permissions` block with the minimum necessary set of privileges. As the workflow only checks out code, runs scripts, and does not interact with issues or pull requests, only `contents: read` should be granted. This should be added at the top level of the workflow file (i.e., directly under the workflow `name` and before the jobs list) to apply to all jobs unless overridden elsewhere. The minimal edit is to add:

```yaml
permissions:
  contents: read
```
after the `name: Build` line. No other changes or additions (such as packages or code changes) are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->