### PR TITLE
fix(codeql): add CodeQL workflow scoped to Python only

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,11 @@
+name: "Parrot MCP Server CodeQL Config"
+
+# Only scan Python source — exclude workflow YAML files to prevent CodeQL
+# from attempting to process GitHub Actions syntax (exit code 32 failure).
+paths:
+  - src/parrot_mcp_server
+
+paths-ignore:
+  - .github/workflows
+  - node_modules
+  - "**/*.bats"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Run weekly on Mondays at 08:00 UTC
+    - cron: '0 8 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          # Scan Python only — the project has no JavaScript/TypeScript.
+          # Omitting 'actions' language prevents CodeQL from attempting to
+          # process .github/workflows YAML, which causes exit code 32 when
+          # no supported Actions constructs are found.
+          languages: python
+          config-file: .github/codeql-config.yml
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -e .
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:python'


### PR DESCRIPTION
Resolves the CodeQL finalize exit-code-32 failure that occurs when
CodeQL detects GitHub Actions YAML but cannot process it.

Changes:
- Add .github/workflows/codeql.yml scanning Python only (no 'actions'
  language entry, which was the root cause of the finalize failure)
- Add .github/codeql-config.yml restricting scan paths to
  src/parrot_mcp_server and explicitly excluding .github/workflows,
  node_modules, and *.bats test files
- Set required permissions: security-events:write, contents:read,
  actions:read
- Add weekly scheduled scan (Mondays 08:00 UTC) in addition to
  push/PR triggers

https://claude.ai/code/session_01KoZkihE3pav4uBvobDAmKs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated code quality and security analysis to run on commits to main, pull requests, and on a weekly schedule to maintain code standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->